### PR TITLE
Correção nas options do select antifa-label

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
             </div>
             <div class="form-group">
                 <select id='antifa-label'>
-                    <option>Antifacista</option>
-                    <option>Antifacistas</option>
+                    <option>Antifascista</option>
+                    <option>Antifascistas</option>
                 </select>
                 <label for="select" class="control-label"></label><i class="bar"></i>
             </div>


### PR DESCRIPTION
Faltou um "S" nas palavras Antifacista e Antifacistas que se escreve com "SC". Fiz a sugestão de correção mas ficou bem massa o gerador.